### PR TITLE
Release conn builders after projection collection goes out of scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,76 +17,76 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>
 
-cmake_minimum_required( VERSION 3.19 )
+cmake_minimum_required(VERSION 3.19)
 
 # add cmake modules: for all `include(...)` first look here
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-project( nest CXX C )
-set( NEST_USER_EMAIL "users@nest-simulator.org" )
+project(nest CXX C)
+set(NEST_USER_EMAIL "users@nest-simulator.org")
 
-include( ColorMessages )
+include(ColorMessages)
 
 # check if the given CMAKE_INSTALL_PREFIX is not empty
-if("${CMAKE_INSTALL_PREFIX}" STREQUAL "")
-  printError("CMAKE_INSTALL_PREFIX cannot be an empty string")
-endif()
+if ("${CMAKE_INSTALL_PREFIX}" STREQUAL "")
+    printError("CMAKE_INSTALL_PREFIX cannot be an empty string")
+endif ()
 
 # handle relative installation prefixes
-if( NOT IS_ABSOLUTE ${CMAKE_INSTALL_PREFIX})
+if (NOT IS_ABSOLUTE ${CMAKE_INSTALL_PREFIX})
     # convert relative path to absolute path
     get_filename_component(absPath ${CMAKE_INSTALL_PREFIX} ABSOLUTE BASE_DIR ${CMAKE_BINARY_DIR})
     set(CMAKE_INSTALL_PREFIX ${absPath})
     printInfo("Relative CMAKE_INSTALL_PREFIX has been converted to absolute path ${CMAKE_INSTALL_PREFIX}")
-endif()
+endif ()
 
 ################################################################################
 ##################         All User Defined options           ##################
 ################################################################################
 
 # use Python to build PyNEST
-set( with-python ON CACHE STRING "Build PyNEST [default=ON]." )
-option( cythonize-pynest "Use Cython to cythonize pynestkernel.pyx [default=ON]. If OFF, PyNEST has to be build from a pre-cythonized pynestkernel.pyx." ON )
+set(with-python ON CACHE STRING "Build PyNEST [default=ON].")
+option(cythonize-pynest "Use Cython to cythonize pynestkernel.pyx [default=ON]. If OFF, PyNEST has to be build from a pre-cythonized pynestkernel.pyx." ON)
 
 # select parallelization scheme
-set( with-mpi OFF CACHE STRING "Build with MPI parallelization [default=OFF]." )
-set( with-openmp ON CACHE BOOL "Build with OpenMP multi-threading [default=ON]. Optionally set OMP compiler flags." )
+set(with-mpi OFF CACHE STRING "Build with MPI parallelization [default=OFF].")
+set(with-openmp ON CACHE BOOL "Build with OpenMP multi-threading [default=ON]. Optionally set OMP compiler flags.")
 
 # external libraries
-set( with-libneurosim OFF CACHE STRING "Build with libneurosim [default=OFF]. Optionally give the directory where libneurosim is installed." )
-set( with-music OFF CACHE STRING "Build with MUSIC [default=OFF]. Optionally give the directory where MUSIC is installed." )
-set( with-sionlib OFF CACHE STRING "Build with SIONlib [default=OFF]. Optionally give the directory where sionlib is installed." )
-set( with-boost ON CACHE STRING "Build with Boost [default=ON]. To set a specific Boost installation, give the install path." )
-set( with-hdf5 OFF CACHE STRING "Find a HDF5 library. To set a specific HDF5 installation, set install path. [default=ON]" )
-set( with-readline ON CACHE STRING "Build with GNU Readline library [default=ON]. To set a specific library, give the install path." )
-set( with-ltdl ON CACHE STRING "Build with ltdl library [default=ON]. To set a specific ltdl, give the  install path. NEST uses ltdl for dynamic loading of external user modules." )
-set( with-gsl ON CACHE STRING "Build with the GSL library [default=ON]. To set a specific library, give the install path." )
+set(with-libneurosim OFF CACHE STRING "Build with libneurosim [default=OFF]. Optionally give the directory where libneurosim is installed.")
+set(with-music OFF CACHE STRING "Build with MUSIC [default=OFF]. Optionally give the directory where MUSIC is installed.")
+set(with-sionlib OFF CACHE STRING "Build with SIONlib [default=OFF]. Optionally give the directory where sionlib is installed.")
+set(with-boost ON CACHE STRING "Build with Boost [default=ON]. To set a specific Boost installation, give the install path.")
+set(with-hdf5 OFF CACHE STRING "Find a HDF5 library. To set a specific HDF5 installation, set install path. [default=ON]")
+set(with-readline ON CACHE STRING "Build with GNU Readline library [default=ON]. To set a specific library, give the install path.")
+set(with-ltdl ON CACHE STRING "Build with ltdl library [default=ON]. To set a specific ltdl, give the  install path. NEST uses ltdl for dynamic loading of external user modules.")
+set(with-gsl ON CACHE STRING "Build with the GSL library [default=ON]. To set a specific library, give the install path.")
 
 # NEST properties
-set( with-modelset "full" CACHE STRING "The modelset to include. Sample configurations are in the modelsets directory. This option is mutually exclusive with -Dwith-models. [default=full]." )
-set( with-models OFF CACHE STRING "The models to include as a semicolon-separated list of model headers (without the .h extension). This option is mutually exclusive with -Dwith-modelset. [default=OFF]." )
-set( tics_per_ms "1000.0" CACHE STRING "Specify elementary unit of time [default=1000 tics per ms]." )
-set( tics_per_step "100" CACHE STRING "Specify resolution [default=100 tics per step]." )
-set( external-modules OFF CACHE STRING "External NEST modules to be linked in, separated by ';', [default=OFF]." )
-set( with-detailed-timers OFF CACHE STRING "Build with detailed internal time measurements [default=OFF]. Detailed timers can affect the performance." )
-set( target-bits-split "standard" CACHE STRING "Split of the 64-bit target neuron identifier type [default='standard']. 'standard' is recommended for most users. If running on more than 262144 MPI processes or more than 512 threads, change to 'hpc'." )
+set(with-modelset "full" CACHE STRING "The modelset to include. Sample configurations are in the modelsets directory. This option is mutually exclusive with -Dwith-models. [default=full].")
+set(with-models OFF CACHE STRING "The models to include as a semicolon-separated list of model headers (without the .h extension). This option is mutually exclusive with -Dwith-modelset. [default=OFF].")
+set(tics_per_ms "1000.0" CACHE STRING "Specify elementary unit of time [default=1000 tics per ms].")
+set(tics_per_step "100" CACHE STRING "Specify resolution [default=100 tics per step].")
+set(external-modules OFF CACHE STRING "External NEST modules to be linked in, separated by ';', [default=OFF].")
+set(with-detailed-timers OFF CACHE STRING "Build with detailed internal time measurements [default=OFF]. Detailed timers can affect the performance.")
+set(target-bits-split "standard" CACHE STRING "Split of the 64-bit target neuron identifier type [default='standard']. 'standard' is recommended for most users. If running on more than 262144 MPI processes or more than 512 threads, change to 'hpc'.")
 
 # generic build configuration
-option( static-libraries "Build static executable and libraries [default=OFF]" OFF )
-set( with-optimize ON CACHE STRING "Enable user defined optimizations [default=ON (uses '-O2')]. When OFF, no '-O' flag is passed to the compiler. Explicit compiler flags can be given; separate multiple flags by ';'." )
-set( with-warning ON CACHE STRING "Enable user defined warnings [default=ON (uses '-Wall')]. Separate  multiple flags by ';'." )
-set( with-debug OFF CACHE STRING "Enable user defined debug flags [default=OFF]. When ON, '-g' is used. Separate  multiple flags by ';'." )
-set( with-cpp-std "c++11" CACHE STRING "C++ standard to use for compilation [default='c++11']." )
-set( with-intel-compiler-flags OFF CACHE STRING "User defined flags for the Intel compiler [default='-fp-model strict']. Separate multiple flags by ';'." )
-set( with-libraries OFF CACHE STRING "Link additional libraries [default=OFF]. Give full path. Separate multiple libraries by ';'." )
-set( with-includes OFF CACHE STRING "Add additional include paths [default=OFF]. Give full path without '-I'. Separate multiple include paths by ';'." )
-set( with-defines OFF CACHE STRING "Additional defines, e.g. '-DXYZ=1' [default=OFF]. Separate multiple defines by ';'." )
+option(static-libraries "Build static executable and libraries [default=OFF]" OFF)
+set(with-optimize ON CACHE STRING "Enable user defined optimizations [default=ON (uses '-O2')]. When OFF, no '-O' flag is passed to the compiler. Explicit compiler flags can be given; separate multiple flags by ';'.")
+set(with-warning ON CACHE STRING "Enable user defined warnings [default=ON (uses '-Wall')]. Separate  multiple flags by ';'.")
+set(with-debug OFF CACHE STRING "Enable user defined debug flags [default=OFF]. When ON, '-g' is used. Separate  multiple flags by ';'.")
+set(with-cpp-std "c++17" CACHE STRING "C++ standard to use for compilation [default='c++17'].")
+set(with-intel-compiler-flags OFF CACHE STRING "User defined flags for the Intel compiler [default='-fp-model strict']. Separate multiple flags by ';'.")
+set(with-libraries OFF CACHE STRING "Link additional libraries [default=OFF]. Give full path. Separate multiple libraries by ';'.")
+set(with-includes OFF CACHE STRING "Add additional include paths [default=OFF]. Give full path without '-I'. Separate multiple include paths by ';'.")
+set(with-defines OFF CACHE STRING "Additional defines, e.g. '-DXYZ=1' [default=OFF]. Separate multiple defines by ';'.")
 
 # documentation build configuration
-set( with-userdoc OFF CACHE STRING "Build user documentation [default=OFF]")
-set( with-devdoc OFF CACHE STRING "Build developer documentation [default=OFF]")
+set(with-userdoc OFF CACHE STRING "Build user documentation [default=OFF]")
+set(with-devdoc OFF CACHE STRING "Build developer documentation [default=OFF]")
 
-set( with-full-logging OFF CACHE STRING "Write debug output to 'dump_<num_ranks>_<rank>.log' file [default=OFF]")
+set(with-full-logging OFF CACHE STRING "Write debug output to 'dump_<num_ranks>_<rank>.log' file [default=OFF]")
 
 ################################################################################
 ##################      Project Directory variables           ##################
@@ -96,31 +96,31 @@ set( with-full-logging OFF CACHE STRING "Write debug output to 'dump_<num_ranks>
 # GNUInstallDirs (included after calling nest_process_with_python()), but the
 # CMAKE_INSTALL_DATADIR is usually just CMAKE_INSTALL_DATAROOTDIR
 # and we want it to be CMAKE_INSTALL_DATAROOTDIR/PROJECT_NAME
-set( CMAKE_INSTALL_DATADIR "share/${PROJECT_NAME}" CACHE STRING "Relative directory, where NEST installs its data (share/nest)" )
+set(CMAKE_INSTALL_DATADIR "share/${PROJECT_NAME}" CACHE STRING "Relative directory, where NEST installs its data (share/nest)")
 
 ################################################################################
 ##################           Find utility programs            ##################
 ################################################################################
 
-find_program( SED NAMES sed gsed )
+find_program(SED NAMES sed gsed)
 
 ################################################################################
 ##################                Load includes               ##################
 ################################################################################
 
 # This include checks the symbols, etc.
-include( CheckIncludesSymbols )
+include(CheckIncludesSymbols)
 
 # These includes publish function names.
-include( ProcessOptions )
-include( WriteStaticModules_h )
-include( CheckExtraCompilerFeatures )
-include( ConfigureSummary )
-include( GetTriple )
+include(ProcessOptions)
+include(WriteStaticModules_h)
+include(CheckExtraCompilerFeatures)
+include(ConfigureSummary)
+include(GetTriple)
 
 # get triples arch-vendor-os
-get_host_triple( NEST_HOST_TRIPLE NEST_HOST_ARCH NEST_HOST_VENDOR NEST_HOST_OS )
-get_target_triple( NEST_TARGET_TRIPLE NEST_TARGET_ARCH NEST_TARGET_VENDOR NEST_TARGET_OS )
+get_host_triple(NEST_HOST_TRIPLE NEST_HOST_ARCH NEST_HOST_VENDOR NEST_HOST_OS)
+get_target_triple(NEST_TARGET_TRIPLE NEST_TARGET_ARCH NEST_TARGET_VENDOR NEST_TARGET_OS)
 
 # Process the command line arguments
 # IMPORTANT: Do not change the order of nest_process_with_python() and include( GNUInstallDirs )!
@@ -128,7 +128,7 @@ get_target_triple( NEST_TARGET_TRIPLE NEST_TARGET_ARCH NEST_TARGET_VENDOR NEST_T
 #            to the active virtual Python environment. This effects the inclusion
 #            of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>.
 nest_process_with_python()
-include( GNUInstallDirs )
+include(GNUInstallDirs)
 nest_post_process_with_python()
 nest_process_with_std()
 nest_process_with_intel_compiler_flags()
@@ -167,10 +167,10 @@ nest_process_with_optimize()
 nest_process_with_debug()
 
 nest_get_color_flags()
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NEST_C_COLOR_FLAGS}" )
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NEST_CXX_COLOR_FLAGS}" )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NEST_C_COLOR_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NEST_CXX_COLOR_FLAGS}")
 
-nest_write_static_module_header( "${PROJECT_BINARY_DIR}/nest/static_modules.h" )
+nest_write_static_module_header("${PROJECT_BINARY_DIR}/nest/static_modules.h")
 
 # check additionals
 nest_check_exitcode_abort()
@@ -186,28 +186,28 @@ nest_check_have_std_nan()
 nest_check_have_std_isnan()
 nest_check_random123()
 
-include( NestVersionInfo )
+include(NestVersionInfo)
 get_version_info()
 printInfo("Done configuring NEST version: ${NEST_VERSION}")
 
 enable_testing()
-set( TEST_OPTS "" )
+set(TEST_OPTS "")
 
-if ( HAVE_PYTHON )
-  set( TEST_OPTS "${TEST_OPTS};--with-python=${PYTHON}" )
+if (HAVE_PYTHON)
+    set(TEST_OPTS "${TEST_OPTS};--with-python=${PYTHON}")
 endif ()
 
-if ( HAVE_MUSIC )
-  set( TEST_OPTS "${TEST_OPTS};--with-music=${MUSIC_EXECUTABLE}" )
+if (HAVE_MUSIC)
+    set(TEST_OPTS "${TEST_OPTS};--with-music=${MUSIC_EXECUTABLE}")
 endif ()
 
-add_custom_target( installcheck
-  COMMAND ${CMAKE_COMMAND} -E env
-    ${CMAKE_INSTALL_FULL_DATADIR}/testsuite/do_tests.sh
-	--prefix=${CMAKE_INSTALL_PREFIX}
-	${TEST_OPTS}
-  WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-  COMMENT "Executing NEST's testsuite..."
+add_custom_target(installcheck
+        COMMAND ${CMAKE_COMMAND} -E env
+        ${CMAKE_INSTALL_FULL_DATADIR}/testsuite/do_tests.sh
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        ${TEST_OPTS}
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+        COMMENT "Executing NEST's testsuite..."
 )
 
 # N.B. to ensure "make install" is always run before "make installcheck", we
@@ -221,20 +221,20 @@ add_custom_target( installcheck
 ##################        Define Subdirectories here          ##################
 ################################################################################
 
-add_subdirectory( doc )
-add_subdirectory( bin )
-add_subdirectory( examples )
-add_subdirectory( build_support )
-add_subdirectory( lib )
-add_subdirectory( libnestutil )
-add_subdirectory( models )
-add_subdirectory( sli )
-add_subdirectory( nest )
-add_subdirectory( nestkernel )
-add_subdirectory( thirdparty )
-add_subdirectory( testsuite )
-if ( HAVE_PYTHON )
-  add_subdirectory( pynest )
+add_subdirectory(doc)
+add_subdirectory(bin)
+add_subdirectory(examples)
+add_subdirectory(build_support)
+add_subdirectory(lib)
+add_subdirectory(libnestutil)
+add_subdirectory(models)
+add_subdirectory(sli)
+add_subdirectory(nest)
+add_subdirectory(nestkernel)
+add_subdirectory(thirdparty)
+add_subdirectory(testsuite)
+if (HAVE_PYTHON)
+    add_subdirectory(pynest)
 endif ()
 
 ################################################################################
@@ -244,111 +244,111 @@ endif ()
 # used in nest-config
 
 # all compiler flags
-if ( NOT CMAKE_BUILD_TYPE OR "${CMAKE_BUILD_TYPE}" STREQUAL "None" )
-  set( ALL_CFLAGS "${CMAKE_C_FLAGS}" )
-  set( ALL_CXXFLAGS "${CMAKE_CXX_FLAGS}" )
-elseif ( ${CMAKE_BUILD_TYPE} STREQUAL "Debug" )
-  set( ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_DEBUG}" )
-  set( ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}" )
-elseif ( ${CMAKE_BUILD_TYPE} STREQUAL "Release" )
-  set( ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_RELEASE}" )
-  set( ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}" )
-elseif ( ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo" )
-  set( ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_RELWITHDEBINFO}" )
-  set( ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" )
-elseif ( ${CMAKE_BUILD_TYPE} STREQUAL "MinSizeRel" )
-  set( ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_MINSIZEREL}" )
-  set( ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_MINSIZEREL}" )
+if (NOT CMAKE_BUILD_TYPE OR "${CMAKE_BUILD_TYPE}" STREQUAL "None")
+    set(ALL_CFLAGS "${CMAKE_C_FLAGS}")
+    set(ALL_CXXFLAGS "${CMAKE_CXX_FLAGS}")
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    set(ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_DEBUG}")
+    set(ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    set(ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_RELEASE}")
+    set(ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+    set(ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    set(ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "MinSizeRel")
+    set(ALL_CFLAGS "${CMAKE_C_FLAGS}   ${CMAKE_C_FLAGS_MINSIZEREL}")
+    set(ALL_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_MINSIZEREL}")
 else ()
-  printError( "Unknown build type: '${CMAKE_BUILD_TYPE}'" )
+    printError("Unknown build type: '${CMAKE_BUILD_TYPE}'")
 endif ()
-if ( with-defines )
-  foreach ( def ${with-defines} )
-    set( ALL_CFLAGS "${def} ${ALL_CFLAGS}" )
-    set( ALL_CXXFLAGS "${def} ${ALL_CXXFLAGS}" )
-  endforeach ()
+if (with-defines)
+    foreach (def ${with-defines})
+        set(ALL_CFLAGS "${def} ${ALL_CFLAGS}")
+        set(ALL_CXXFLAGS "${def} ${ALL_CXXFLAGS}")
+    endforeach ()
 endif ()
 # add sionlib defines
-foreach ( def ${SIONLIB_DEFINES} )
-    set( ALL_CFLAGS "${ALL_CFLAGS} ${def}" )
-    set( ALL_CXXFLAGS "${ALL_CXXFLAGS} ${def}" )
+foreach (def ${SIONLIB_DEFINES})
+    set(ALL_CFLAGS "${ALL_CFLAGS} ${def}")
+    set(ALL_CXXFLAGS "${ALL_CXXFLAGS} ${def}")
 endforeach ()
 
 # libraries required to link extension modules
-set( MODULE_LINK_LIBS
-  "-lnest"
-  "-lsli"
-  "${OpenMP_CXX_FLAGS}"
-  "${LTDL_LIBRARIES}"
-  "${READLINE_LIBRARIES}"
-  "${GSL_LIBRARIES}"
-  "${LIBNEUROSIM_LIBRARIES}"
-  "${MUSIC_LIBRARIES}"
-  "${MPI_CXX_LIBRARIES}"
-  "${SIONLIB_LIBRARIES}"
-  "${BOOST_LIBRARIES}" )
+set(MODULE_LINK_LIBS
+        "-lnest"
+        "-lsli"
+        "${OpenMP_CXX_FLAGS}"
+        "${LTDL_LIBRARIES}"
+        "${READLINE_LIBRARIES}"
+        "${GSL_LIBRARIES}"
+        "${LIBNEUROSIM_LIBRARIES}"
+        "${MUSIC_LIBRARIES}"
+        "${MPI_CXX_LIBRARIES}"
+        "${SIONLIB_LIBRARIES}"
+        "${BOOST_LIBRARIES}")
 
-if ( with-libraries )
-  set( MODULE_LINK_LIBS "${MODULE_LINK_LIBS};${with-libraries}" )
+if (with-libraries)
+    set(MODULE_LINK_LIBS "${MODULE_LINK_LIBS};${with-libraries}")
 endif ()
-string( REPLACE ";" " " MODULE_LINK_LIBS "${MODULE_LINK_LIBS}" )
+string(REPLACE ";" " " MODULE_LINK_LIBS "${MODULE_LINK_LIBS}")
 
 # libraries requied to link NEST
-set( ALL_LIBS
-  "-lnest"
-  ${MODULE_LINK_LIBS} )
+set(ALL_LIBS
+        "-lnest"
+        ${MODULE_LINK_LIBS})
 
 
 # all includes
-set( ALL_INCLUDES_tmp
-  "${CMAKE_INSTALL_FULL_INCLUDEDIR}/nest"
-  "${LTDL_INCLUDE_DIRS}"
-  "${READLINE_INCLUDE_DIRS}"
-  "${GSL_INCLUDE_DIRS}"
-  "${LIBNEUROSIM_INCLUDE_DIRS}"
-  "${MUSIC_INCLUDE_DIRS}"
-  "${MPI_CXX_INCLUDE_PATH}"
-  "${BOOST_INCLUDE_DIR}" )
-set( ALL_INCLUDES "" )
-foreach ( INC ${ALL_INCLUDES_tmp} ${with-includes} )
-  if ( INC AND NOT INC STREQUAL "" )
-    set( ALL_INCLUDES "${ALL_INCLUDES} -I${INC}" )
-  endif ()
+set(ALL_INCLUDES_tmp
+        "${CMAKE_INSTALL_FULL_INCLUDEDIR}/nest"
+        "${LTDL_INCLUDE_DIRS}"
+        "${READLINE_INCLUDE_DIRS}"
+        "${GSL_INCLUDE_DIRS}"
+        "${LIBNEUROSIM_INCLUDE_DIRS}"
+        "${MUSIC_INCLUDE_DIRS}"
+        "${MPI_CXX_INCLUDE_PATH}"
+        "${BOOST_INCLUDE_DIR}")
+set(ALL_INCLUDES "")
+foreach (INC ${ALL_INCLUDES_tmp} ${with-includes})
+    if (INC AND NOT INC STREQUAL "")
+        set(ALL_INCLUDES "${ALL_INCLUDES} -I${INC}")
+    endif ()
 endforeach ()
-set( ALL_INCLUDES "${ALL_INCLUDES} ${SIONLIB_INCLUDE}" )
+set(ALL_INCLUDES "${ALL_INCLUDES} ${SIONLIB_INCLUDE}")
 
 ################################################################################
 ##################           File generation here             ##################
 ################################################################################
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/libnestutil/config.h.in"
-    "${PROJECT_BINARY_DIR}/libnestutil/config.h" @ONLY
+        "${PROJECT_SOURCE_DIR}/libnestutil/config.h.in"
+        "${PROJECT_BINARY_DIR}/libnestutil/config.h" @ONLY
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/pynest/setup.py.in"
-    "${PROJECT_BINARY_DIR}/pynest/setup.py" @ONLY
+        "${PROJECT_SOURCE_DIR}/pynest/setup.py.in"
+        "${PROJECT_BINARY_DIR}/pynest/setup.py" @ONLY
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/bin/nest-config.in"
-    "${PROJECT_BINARY_DIR}/bin/nest-config" @ONLY
+        "${PROJECT_SOURCE_DIR}/bin/nest-config.in"
+        "${PROJECT_BINARY_DIR}/bin/nest-config" @ONLY
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/bin/nest_vars.sh.in"
-    "${PROJECT_BINARY_DIR}/bin/nest_vars.sh" @ONLY
+        "${PROJECT_SOURCE_DIR}/bin/nest_vars.sh.in"
+        "${PROJECT_BINARY_DIR}/bin/nest_vars.sh" @ONLY
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/doc/fulldoc.conf.in"
-    "${PROJECT_BINARY_DIR}/doc/fulldoc.conf" @ONLY
+        "${PROJECT_SOURCE_DIR}/doc/fulldoc.conf.in"
+        "${PROJECT_BINARY_DIR}/doc/fulldoc.conf" @ONLY
 )
 
 configure_file(
-    "${PROJECT_SOURCE_DIR}/pynest/nest/versionchecker.py.in"
-    "${PROJECT_BINARY_DIR}/pynest/nest/versionchecker.py" @ONLY
+        "${PROJECT_SOURCE_DIR}/pynest/nest/versionchecker.py.in"
+        "${PROJECT_BINARY_DIR}/pynest/nest/versionchecker.py" @ONLY
 )
 
 
@@ -356,8 +356,8 @@ configure_file(
 ##################            Install Extra Files             ##################
 ################################################################################
 
-install( FILES LICENSE README.md
-    DESTINATION ${CMAKE_INSTALL_DOCDIR}
-    )
+install(FILES LICENSE README.md
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)
 
 nest_print_config_summary()

--- a/nestkernel/conn_builder_factory.h
+++ b/nestkernel/conn_builder_factory.h
@@ -49,7 +49,7 @@ public:
   virtual ~GenericConnBuilderFactory()
   {
   }
-  virtual ConnBuilder* create( NodeCollectionPTR,
+  virtual std::unique_ptr< ConnBuilder > create( NodeCollectionPTR,
     NodeCollectionPTR,
     const DictionaryDatum&,
     const std::vector< DictionaryDatum >& ) const = 0;
@@ -65,13 +65,13 @@ class ConnBuilderFactory : public GenericConnBuilderFactory
 
 public:
   //! create conn builder
-  ConnBuilder*
+  std::unique_ptr< ConnBuilder >
   create( NodeCollectionPTR sources,
     NodeCollectionPTR targets,
     const DictionaryDatum& conn_spec,
     const std::vector< DictionaryDatum >& syn_specs ) const override
   {
-    return new ConnBuilderType( sources, targets, conn_spec, syn_specs );
+    return std::make_unique< ConnBuilderType >( sources, targets, conn_spec, syn_specs );
   }
 };
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -350,7 +350,7 @@ nest::ConnectionManager::get_user_set_delay_extrema() const
   return user_set_delay_extrema;
 }
 
-nest::ConnBuilder*
+std::unique_ptr< nest::ConnBuilder >
 nest::ConnectionManager::get_conn_builder( const std::string& name,
   NodeCollectionPTR sources,
   NodeCollectionPTR targets,
@@ -358,7 +358,8 @@ nest::ConnectionManager::get_conn_builder( const std::string& name,
   const std::vector< DictionaryDatum >& syn_specs )
 {
   const size_t rule_id = connruledict_->lookup( name );
-  ConnBuilder* cb = connbuilder_factories_.at( rule_id )->create( sources, targets, conn_spec, syn_specs );
+  std::unique_ptr< ConnBuilder > cb =
+    connbuilder_factories_.at( rule_id )->create( sources, targets, conn_spec, syn_specs );
   assert( cb );
   return cb;
 }

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -95,7 +95,7 @@ public:
   template < typename ConnBuilder >
   void register_conn_builder( const std::string& name );
 
-  ConnBuilder* get_conn_builder( const std::string& name,
+  std::unique_ptr< ConnBuilder > get_conn_builder( const std::string& name,
     NodeCollectionPTR sources,
     NodeCollectionPTR targets,
     const DictionaryDatum& conn_spec,

--- a/nestkernel/projection_collection.cpp
+++ b/nestkernel/projection_collection.cpp
@@ -43,7 +43,8 @@ ProjectionCollection::ProjectionCollection( const ArrayDatum& projections )
     auto conn_spec = getValue< DictionaryDatum >( projection_array[ 2 ] );
     if ( is_spatial )
     {
-      projections_.emplace_back( new ConnectionClassWrapper_::SpatialBuilderWrapper_( sources, targets, conn_spec ) );
+      projections_.emplace_back(
+        std::make_unique< ConnectionClassWrapper_::SpatialBuilderWrapper_ >( sources, targets, conn_spec ) );
       // TODO: delete builder in destructor, or put it in smart pointer
       post_spatial_connector_creation_checks( conn_spec ); // checks of dictionary access flags
     }
@@ -57,7 +58,6 @@ ProjectionCollection::ProjectionCollection( const ArrayDatum& projections )
         synapse_params.begin(),
         // Lambda expression that handles the conversion of each element.
         []( Token& token ) -> DictionaryDatum { return getValue< DictionaryDatum >( token ); } );
-
       // Need to do the same checks of arguments as in ConnectionManager::connect().
       pre_connector_creation_checks( sources, targets, conn_spec, synapse_params );
       const auto rule_name = static_cast< const std::string >( ( *conn_spec )[ names::rule ] );
@@ -160,15 +160,16 @@ ProjectionCollection::post_spatial_connector_creation_checks( DictionaryDatum& c
 }
 
 
-ProjectionCollection::ConnectionClassWrapper_::ConnectionClassWrapper_( ConnBuilder* const conn_builder )
-  : conn_builder_( conn_builder )
+ProjectionCollection::ConnectionClassWrapper_::ConnectionClassWrapper_( std::unique_ptr< ConnBuilder > conn_builder )
+  : conn_builder_( std::move( conn_builder ) )
   , spatial_conn_creator_( nullptr )
 {
 }
 
-ProjectionCollection::ConnectionClassWrapper_::ConnectionClassWrapper_( SpatialBuilderWrapper_* const spatial_builder )
+ProjectionCollection::ConnectionClassWrapper_::ConnectionClassWrapper_(
+  std::unique_ptr< SpatialBuilderWrapper_ > spatial_builder )
   : conn_builder_( nullptr )
-  , spatial_conn_creator_( spatial_builder )
+  , spatial_conn_creator_( std::move( spatial_builder ) )
 {
 }
 

--- a/nestkernel/projection_collection.cpp
+++ b/nestkernel/projection_collection.cpp
@@ -45,7 +45,6 @@ ProjectionCollection::ProjectionCollection( const ArrayDatum& projections )
     {
       projections_.emplace_back(
         std::make_unique< ConnectionClassWrapper_::SpatialBuilderWrapper_ >( sources, targets, conn_spec ) );
-      // TODO: delete builder in destructor, or put it in smart pointer
       post_spatial_connector_creation_checks( conn_spec ); // checks of dictionary access flags
     }
     else
@@ -63,7 +62,6 @@ ProjectionCollection::ProjectionCollection( const ArrayDatum& projections )
       const auto rule_name = static_cast< const std::string >( ( *conn_spec )[ names::rule ] );
       projections_.emplace_back(
         kernel().connection_manager.get_conn_builder( rule_name, sources, targets, conn_spec, synapse_params ) );
-      // TODO: delete builder in destructor, or put it in smart pointer
       post_connector_creation_checks( conn_spec, synapse_params ); // checks of dictionary access flags
     }
   }

--- a/nestkernel/projection_collection.h
+++ b/nestkernel/projection_collection.h
@@ -25,9 +25,9 @@
 
 #include <vector>
 
+#include "connection_creator.h"
 #include "dictutils.h"
 #include "nest_datums.h"
-#include "connection_creator.h"
 #include "spatial.h"
 
 
@@ -59,18 +59,20 @@ private:
       ConnectionCreator spatial_builder;
     };
     ConnectionClassWrapper_() = delete;
+    ConnectionClassWrapper_( const ConnectionClassWrapper_& ) = delete;
+    ConnectionClassWrapper_( ConnectionClassWrapper_&& ) = default;
     // Regular connections
-    ConnectionClassWrapper_( ConnBuilder* const );
+    ConnectionClassWrapper_( std::unique_ptr< ConnBuilder > );
     // Spatial connections
-    ConnectionClassWrapper_( SpatialBuilderWrapper_* const );
+    ConnectionClassWrapper_( std::unique_ptr< SpatialBuilderWrapper_ > );
 
     void connect();
 
   private:
     // Regular connections
-    ConnBuilder* const conn_builder_;
+    std::unique_ptr< ConnBuilder > conn_builder_;
     // Spatial connections
-    SpatialBuilderWrapper_* const spatial_conn_creator_;
+    std::unique_ptr< SpatialBuilderWrapper_ > spatial_conn_creator_;
   };
 
   std::vector< ConnectionClassWrapper_ > projections_;

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -233,7 +233,7 @@ SPManager::disconnect( NodeCollectionPTR sources,
     }
   }
 
-  ConnBuilder* cb = nullptr;
+  std::unique_ptr< ConnBuilder > cb = nullptr;
   conn_spec->clear_access_flags();
   syn_spec->clear_access_flags();
 
@@ -275,8 +275,6 @@ SPManager::disconnect( NodeCollectionPTR sources,
   // Set flag before calling cb->disconnect() in case exception is thrown after some connections have been removed.
   kernel().connection_manager.set_connections_have_changed();
   cb->disconnect();
-
-  delete cb;
 }
 
 void


### PR DESCRIPTION
Attached, see the logs for memory consumption on a 1m neuron, 100k, fixed indegree 200 connection test for (all Stages/2024):

- [Master 3.6](https://github.com/otcathatsya/nest-simulator/files/14335648/master-2024-rep-out.txt)
- [Pre-fix Exabrainprep](https://github.com/otcathatsya/nest-simulator/files/14335660/old-exa-2024-rep-out.txt)
- [Fixed Exabrainprep](https://github.com/otcathatsya/nest-simulator/files/14335661/fixed-exa-2024-rep-out.txt)

Additionally, [Microcircuit, fixed Exabrainprep](https://github.com/otcathatsya/nest-simulator/files/14335677/microcircuit-exa-fixed.csv)


Weirdly the times seem less advantageous compared to master than the initial exabrainprep connection tests, though I may have just mixed up some cmake args; will investigate tomorrow, memory seems good (and actually lower than master at scale).